### PR TITLE
tweak passthrough to show queries

### DIFF
--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -14,16 +14,18 @@ struct PassthroughHandler {}
 #[async_trait::async_trait]
 impl PacketHandler for PassthroughHandler {
     async fn handle_request(&mut self, p: &Packet) -> Packet {
-        debug!(
-            "c=>s: {:?} packet: {} bytes",
+        info!(
+            "c=>s: {:?} packet: {} bytes content={:?}",
             p.get_packet_type(),
-            p.get_size()
+            p.get_size(),
+            p.get_content()
         );
         p.clone()
     }
 
     async fn handle_response(&mut self, p: &Packet) -> Packet {
-        debug!(
+        // dont care about content of the response
+        info!(
             "c<=s: {:?} packet: {} bytes",
             p.get_packet_type(),
             p.get_size()

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,4 +1,5 @@
 use std::io::{Error, ErrorKind};
+use std::str::from_utf8;
 
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
 
@@ -58,6 +59,14 @@ impl Packet {
                 Ok(String::from_utf8(self.bytes[5..].to_vec()).expect("Invalid UTF-8"))
             }
             _ => Err(Error::new(ErrorKind::Other, "Packet is not a query")),
+        }
+    }
+
+    pub fn get_content(&self) -> String {
+        // translate bytes to string
+        match from_utf8(&self.bytes) {
+            Ok(v) => v.to_string(),
+            Err(_) => "{binary}".to_string(),
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -116,7 +116,7 @@ impl Server {
                     trace!("Server.run(): new incoming connection");
                     if let Some(conn) = some_conn {
                         match conn {
-                            Ok(mut client_socket) => {
+                            Ok(client_socket) => {
                                 trace!("Server.run(): got the client_socket");
                                 let (tx, rx) = oneshot::channel();
                                 self.kill_switches.push(tx);


### PR DESCRIPTION
output of running `select version()`:

```
[2024-01-18T14:52:06Z INFO  passthrough] c=>s: Ok(Query) packet: 22 bytes content="Q\0\0\0\u{15}select version()\0"
[2024-01-18T14:52:06Z INFO  passthrough] c<=s: Ok(RowDescription) packet: 33 bytes
[2024-01-18T14:52:06Z INFO  passthrough] c<=s: Ok(DataRow) packet: 137 bytes
[2024-01-18T14:52:06Z INFO  passthrough] c<=s: Ok(Close) packet: 14 bytes
[2024-01-18T14:52:06Z INFO  passthrough] c<=s: Ok(ReadyForQuery) packet: 6 bytes
[2024-01-18T14:52:15Z INFO  passthrough] c=>s: Ok(Terminate) packet: 5 bytes content="X\0\0\0\u{4}"
```